### PR TITLE
Fix tests to not use invalid quantities (e.g. 0x02)

### DIFF
--- a/rpc-specs-tests/tests/eth_getBlockByNumber.json
+++ b/rpc-specs-tests/tests/eth_getBlockByNumber.json
@@ -14,7 +14,7 @@
       "title": "eth_getBlockByNumber without full transactions",
       "request" : {
         "method" : "eth_getBlockByNumber",
-        "params" : ["0x02", false]
+        "params" : ["0x2", false]
       },
       "expectedResponse" : {
         "result": {
@@ -61,7 +61,7 @@
       "title": "eth_getBlockByNumber with full transactions",
       "request" : {
         "method" : "eth_getBlockByNumber",
-        "params" : ["0x02", true]
+        "params" : ["0x2", true]
       },
       "expectedResponse" : {
         "result": {
@@ -146,7 +146,7 @@
       "title": "eth_getBlockByNumber with one parameter",
       "request" : {
         "method" : "eth_getBlockByHash",
-        "params" : ["0x02"],
+        "params" : ["0x2"],
         "shouldFailSchema": true
       },
       "expectedResponse" : {

--- a/rpc-specs-tests/tests/eth_getBlockTransactionCountByNumber.json
+++ b/rpc-specs-tests/tests/eth_getBlockTransactionCountByNumber.json
@@ -14,7 +14,7 @@
       "title": "eth_getBlockTransactionCountByNumber for block with one tx",
       "request" : {
         "method" : "eth_getBlockTransactionCountByNumber",
-        "params" : ["0x04"]
+        "params" : ["0x4"]
       },
       "expectedResponse" : {
         "result": "0x1"

--- a/rpc-specs-tests/tests/eth_getUncleCountByBlockNumber.json
+++ b/rpc-specs-tests/tests/eth_getUncleCountByBlockNumber.json
@@ -14,7 +14,7 @@
       "title": "eth_getUncleCountByBlockNumber for block with two uncles",
       "request" : {
         "method" : "eth_getUncleCountByBlockNumber",
-        "params" : ["0x04"]
+        "params" : ["0x4"]
       },
       "expectedResponse" : {
         "result": "0x2"


### PR DESCRIPTION
According to https://github.com/ethereum/wiki/wiki/JSON-RPC, quantities should have the 0x prefix but no leading zeroes.